### PR TITLE
Advanced Menu Overwritten Fix

### DIFF
--- a/hook_post_action_bmm/hook_post_action_bmm.module
+++ b/hook_post_action_bmm/hook_post_action_bmm.module
@@ -15,11 +15,11 @@ require_once(drupal_get_path('module', 'better_mm') . '/includes/helpers.inc');
 function hook_post_action_bmm_node_postinsert($node) {
   $menu = $node->menu;
   $bmm = variable_get('bmm_menu', '');
-  
+
   if ($menu['enabled']) {
     $parent = explode(':', $menu['parent']);
     $menu_name = $parent[0];
-	
+
 	// If the menu we're editing is the BMM and if the current node being
 	// inserted is at the root level of the menu, add it to the BMM form
 	// settings variable
@@ -27,7 +27,7 @@ function hook_post_action_bmm_node_postinsert($node) {
       if(strpos($menu['parent'], $parent[0] . ':0') !== FALSE) {
         saveToBMMItemSettings($node->menu['link_title'], $node->menu['mlid']);
       }
-	  
+
       $bmm_block_content = bmm_gen_block_html($bmm);
       variable_set('bmm_block_content', $bmm_block_content['html']);
       variable_set('bmm_mobile_block_content', $bmm_block_content['mobile']);
@@ -48,19 +48,29 @@ function hook_post_action_bmm_node_postinsert($node) {
  */
 function hook_post_action_bmm_node_postupdate($node) {
   $menu = $node->menu;
+  $link_title = strtolower($node->menu['link_title']);
+  $link_mlid = $node->menu['mlid'];
+  $menu_settings = variable_get('bmm_menu_items_settings');
   $bmm = variable_get('bmm_menu', '');
+
   if ($menu['enabled']) {
     $parent = explode(':', $menu['parent']);
     $menu_name = $parent[0];
-    
+
 	// If the menu being edited is the BMM and the currently updated node
 	// is in the root level of the menu, add a setting for the BMM form
 	// settings variable
-    if ($menu_name == $bmm) {
+  if ($menu_name == $bmm) {
 	  if(strpos($menu['parent'], $parent[0] . ':0') !== FALSE) {
-        saveToBMMItemSettings($node->menu['link_title'], $node->menu['mlid']);
+        if((isset($menu_settings[$link_title])
+          && $menu_settings[$link_title]['style'] != 'advanced') ||
+          (isset($menu_settings[$link_mlid]) &&
+          $menu_settings[$link_mlid]['style'] != 'advanced')) {
+          
+          saveToBMMItemSettings($node->menu['link_title'], $node->menu['mlid']);
+        }
       }
-	  
+
       $bmm_block_content = bmm_gen_block_html($bmm);
       variable_set('bmm_block_content', $bmm_block_content['html']);
       variable_set('bmm_mobile_block_content', $bmm_block_content['mobile']);
@@ -85,7 +95,7 @@ function hook_post_action_bmm_node_postupdate($node) {
  */
 function hook_post_action_bmm_node_postdelete($node) {
   $bmm = variable_get('bmm_menu', '');
-  
+
   $bmm_block_content = bmm_gen_block_html($bmm);
   variable_set('bmm_block_content', $bmm_block_content['html']);
   variable_set('bmm_mobile_block_content', $bmm_block_content['mobile']);


### PR DESCRIPTION
Fixed an issue with the BMM that resulted in an advanced menu item being overwritten with a standard menu in the BMM settings after a node was saved.